### PR TITLE
Convert Exception to RuntimeError when FEE missing

### DIFF
--- a/src/dxtbx/format/FormatXTC.py
+++ b/src/dxtbx/format/FormatXTC.py
@@ -424,7 +424,12 @@ class FormatXTC(FormatMultiImageLazy, FormatStill, Format):
         return self.n_images
 
     def get_beam(self, index=None):
-        return self._beam(index)
+        beam = self._beam(index)
+        if beam is not None:
+          return self._beam(index)
+        else:
+          raise(RuntimeError("image has no beam"))
+
 
     def _beam(self, index=None):
         """Returns a simple model for the beam"""


### PR DESCRIPTION
Currently get_beam will always return something, but when that something is None, downstream processes raise an Exception that is much harder to track down the source of and that kills the process. Raising a RuntimeError here instead makes clear that the issue is the missing FEE spectrum from one event and allows cctbx.xfel.process to skip the event and proceed to the next.

Co-authored by: Aaron Brewster